### PR TITLE
mongo and mysql seed only option

### DIFF
--- a/bin/seed
+++ b/bin/seed
@@ -21,6 +21,7 @@ case $selection in
       -v `pwd`/deploy/mysql/data:/docker-entrypoint-initdb.d \
       -p 3306:3306 \
       -e MYSQL_RANDOM_ROOT_PASSWORD=1 \
+      -e SEED_ONLY=1 \
       burnerdev/mysql:5.7
     ;;
   2)
@@ -30,6 +31,7 @@ case $selection in
       -v `pwd`/.volumes/mongo/configdb:/data/configdb/ \
       -v `pwd`/deploy/mongo/data:/docker-entrypoint-initdb.d \
       -p 27017:27017 \
+      -e SEED_ONLY=1 \
       burnerdev/mongo:3.4
     ;;
   3)

--- a/deploy/mongo/docker-entrypoint.sh
+++ b/deploy/mongo/docker-entrypoint.sh
@@ -98,4 +98,11 @@ if [ "$1" = 'mongod' -a -z "$wantHelp" ]; then
 	fi
 fi
 
-exec "$@"
+# if seed only do not start process
+if [ ! -z "$SEED_ONLY" ]; then
+	echo
+	echo 'MongoDB seed process done.'
+	echo
+else
+	exec "$@"
+fi	

--- a/deploy/mysql/docker-entrypoint.sh
+++ b/deploy/mysql/docker-entrypoint.sh
@@ -180,4 +180,11 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 	fi
 fi
 
-exec "$@"
+# if seed only do not start process
+if [ ! -z "$SEED_ONLY" ]; then
+	echo
+	echo 'MySQL seed process done.'
+	echo
+else
+	exec "$@"
+fi	


### PR DESCRIPTION
added a SEED_ONLY env var to mysql and mongo container images
when this value is set the main service process will not start after seeding databases

should satisfy 
#6 
#7 
#8 
#9 

updated images are already pushed to dockerhub
devs will need to rerun setup after this work is merged and pulled

<!---
@huboard:{"custom_state":"archived"}
-->
